### PR TITLE
Add missing initializer for tp_print

### DIFF
--- a/Lib/python/pyrun.swg
+++ b/Lib/python/pyrun.swg
@@ -696,12 +696,15 @@ SwigPyObject_TypeOnce(void) {
 #if PY_VERSION_HEX >= 0x03040000
       0,                                    /* tp_finalize */
 #endif
+#if PY_VERSION_HEX < 0x03090000
+      0,                                    /* tp_print */
 #ifdef COUNT_ALLOCS
       0,                                    /* tp_allocs */
       0,                                    /* tp_frees */
       0,                                    /* tp_maxalloc */
       0,                                    /* tp_prev */
       0                                     /* tp_next */
+#endif
 #endif
     };
     swigpyobject_type = tmp;


### PR DESCRIPTION
tp_print is still here for 3.8 and disappears for python 3.9:
https://github.com/python/cpython/blob/v3.9.0a4/Include/cpython/object.h#L273
tp_print, tp_frees... etc are removed also